### PR TITLE
Rephrase abstract

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -130,82 +130,83 @@
 % \affiliationv{JüriBölüm, Ankara University}
 %
 % Keywords : English & Turkish, Comma seperated
-\keywords{autonomous car,
+\keywords{
+    autonomous car,
     traffic scene parsing,
     traffic sign classification,
-    behavior planning,
     optimal trajectory planning,
     pure pursuit controller
-    }
-\anahtarklm{otonom araç,
+}
+\anahtarklm{
+    otonom araç,
     trafik sahnesi ayrıştırma,
     trafik işareti sınıflandırması,
-    davranış planlayıcı,
     optimal yörünge planlayıcı,
     pure pursuit kontrolcüsü
-    }
+}
 %
 % Abstract in English
 %
 \abstract{
     Autonomous cars capable of driving in city traffic has been long studied in
-    decomposed architectures with perception, planning, and control components.
-    Recent advances in deep learning techniques considerably contributed to the
-    perception component of this approach. These advances also led to evolution
-    of other approaches such as end-to-end learning steering commands and more
-    recently learning driving affordances from raw camera images. Though the
-    latter approaches are promising to simplify the overall architecture to
-    some extent, the former is found more persuasive constituting the majority of
-    today's state-of-art self-driving cars close to market. However, studies on
-    autonomous small-scale cars which are supposed to be fast and and low-cost
-    protptyping platforms are not a par with the state-of-art decomposed
-    architectures. They often remain limited to end-to-end approaches or resort
-    to tranditional computer vision techniques in oversimplified traffic
-    scenarios. To address this problem, we proposed a decomposed architecture
-    for small-scale cars covering the extended traffic scenarios with seven
-    traffic signs, traffic lights, lane shifts, cloverleaf interchange,
-    pedestrian crossings, and parking. We created a traffic scene segmentation
-    dataset filling a gap for autonomous mini cars. We learned semantics of
-    lanes and classified traffic lights and signs with deep learning models.
-    Given the visual information as well as the detected obstacles by laser
-    scans, we decided on the best behavior for the car with a rule-based
-    system. Using the interpretation of the scene in terms of the behavior and
-    perception, we found optimal trajectories along the lanes and followed them
-    with a controller. With our novel lane segmentation scheme and 97\%
-    accuracy classifier, we achieved successful results along our courses in
-    real and simulation domains.
+    decomposed architectures consisting of perception, planning, and control
+    components. Recent advances in deep learning techniques considerably
+    contributed to the perception component of this approach. These advances
+    also led to evolution of other approaches such as end-to-end learning
+    steering commands from camera images and more recently, learning driving
+    affordances. Though the latter approaches are promising to simplify the
+    overall architecture, the former is found more persuasive constituting the
+    majority of today's state-of-the-art, market-oriented driverless cars.
+    However, studies on small-scale autonomous cars, which can be considered as
+    low-cost and rapid prototyping platforms, are not on a par with research on
+    the modern decomposed architectures. These studies often remain limited to
+    end-to-end approaches or resort to traditional image processing techniques
+    in over-simplified traffic scenarios. In this work, we present a decomposed
+    architecture for small-scale cars covering extended traffic scenarios with
+    seven traffic signs, traffic lights, lane changes, cloverleaf interchange,
+    pedestrian crossings, and parking. To realize this architecture, we created
+    segmentation and classification datasets. We trained two deep learning
+    models for learning lane semantics and classifying traffic signs and
+    lights. We developed a rule-based behavior planner to decide on the best
+    behavior primitives for traffic scenes. Based on these behavior primitives,
+    we implemented a trajectory planner to find optimal trajectories along the
+    lanes and a controller to follow these trajectories.  With our novel lane
+    segmentation scheme, \%97 accuracy classifier, robust planner and
+    controller algorithms, we achieved successful drives on simulated and real
+    courses.
 }
 %
 % Turkish Abstract
 %
 \oz{
-    Şehir trafiğinde sürüş yapabilen otonom araçlar algı, planlama ve control
-    bileşenleriyle ayrılmış mimariler içinde uzun zamandır çalışılmaktadır.
-    Derin öğrenme tekniklerindeki son gelişmeler bu yaklaşımın algı bileşenine
-    büyük ölçüde katkıda bulunmuştur. Bu bileşenler ayrıca kamera görüntüsü
-    üzerinden uçtan uca yönelim komutlarını öğrenme ve daha yenisi sürüş
-    sağlarlıklarını öğrenmek gibi yeni yaklaşımların da gelişiminde etken
-    olmuştur. Sonraki yaklaşımlar genel mimariyi bir derece sadeleştirmek için
-    ümit verici olsa da bugünün pazara yakın olan en gelişmiş kendi kendini
-    sürebilen araçların çoğunluğunu oluşturan ilk yaklaşım daha ikna edici
-    bulunmaktadır. Bununla birlikte, hızlı ve düşük bütçeli protipleme
-    platformu olması beklenen küçük ölçekli otonom araçlar üzerinde yapılan
-    çalışmalar en gelişmiş ayrışmış mimariler ile aynı düzeyde değildir. Bu
-    çalışmalar genellikle uçtan uca yaklaşımlarla sınırlı kalmakta veya aşırı
-    basitleştirilmiş trafik senaryoları içinde geleneksel görüntü işleme
-    yöntemlerine başvurmaktadır. Bu problemi ele almak adına biz küçük ölçekli
-    araçlar için yedi trafik işareti, trafik lambaları, şerit değiştirmeler,
-    yonca kavşak, yaya geçişleri ve park işlemi ile genişletilmiş trafik
-    senaryolarını kapsayan ayrışmış bir mimari sunduk. Otonom küçük araçlar
-    için bir boşluğu doldurarak trafik sahnesi bölümleme veri seti oluşturduk.
-    Derin öğrenme modelleri kullanarak şeritlerin anlamlarını öğrendik ve
-    trafik lamba ve işaretlerini sınıflandırdık. Kural tabanlı bir sistem ile
-    verilen görsel bilgi ve laser taramalarıyla tespit edilen engellere göre
-    araç için en iyi davranışa karar verdik. Davranış ve algı üzerinden yapılan
-    yorumlamayı kullanarak şeritler boyunca en uygun yörüngeleri buduk ve bir
-    kontrolcü ile bu yörüngeleri takip ettik. Özgün şerit bölümleme tasarımız
-    ve \%97 doğruluklu sınıflandırıcımız ile gerçek ve simulasyon ortamlarında
-    güzergahlarımız boyunca başarılı sonuçlar elde ettik.
+    Şehir trafiğinde sürüş yapabilen otonom araçlar algılama, planlama ve
+    kontrol bileşenlerinden oluşan ayrışmış mimariler olarak uzun zamandır
+    çalışılmaktadır. Derin öğrenme tekniklerindeki son gelişmeler bu yaklaşımın
+    algılama bileşenine büyük ölçüde katkıda bulunmuştur. Bu gelişmeler ayrıca
+    kamera görüntüsü üzerinden uçtan uca yönelim komutlarını ve daha güncel
+    olarak sürüş sağlarlıklarını öğrenmek gibi yeni yaklaşımların gelişimini de
+    beraberinde getirmiştir. Sonraki yaklaşımlar genel mimariyi sadeleştirmek
+    için ümit verici olsa da bugünün en gelişmiş, pazara yönelik sürücüsüz
+    araçlarının çoğunluğunu oluşturan ilk yaklaşım daha ikna edici
+    bulunmaktadır. Bununla birlikte, düşük maliyetli ve hızlı prototip
+    oluşturma platformları olarak düşünülebilecek küçük ölçekli otonom araçlar
+    üzerinde yapılan çalışmalar, modern ayrışmış mimariler üzerine yapılan
+    araştırmalarla aynı düzeyde değildir. Bu çalışmalar genellikle uçtan uca
+    yaklaşımlarla sınırlı kalmakta veya aşırı basitleştirilmiş trafik
+    senaryoları içinde geleneksel görüntü işleme yöntemlerine başvurmaktadır.
+    Bu çalışmada, küçük ölçekli araçlar için yedi trafik işareti, trafik
+    ışıkları, şerit değişikliği, yonca yaprağı kavşağı, yaya geçitleri ve park
+    işlemi ile genişletilmiş trafik senaryolarını kapsayan ayrışmış bir mimari
+    sunuyoruz. Bu mimariyi gerçekleştirmek için bölütleme ve sınıflandırma veri
+    setleri oluşturduk. Şerit anlamlarını öğrenmek ve trafik levha ve
+    ışıklarını sınıflandırmak için iki derin öğrenme modeli eğittik. Trafik
+    sahnelerine göre en iyi davranış temellerine karar veren kural tabanlı bir
+    davranış planlayıcısı geliştirdik. Bu davranış temellerine dayanarak, şerit
+    boyunca en uygun yörüngeleri bulan bir yörünge planlayıcısı ve bu
+    yörüngeleri takip etmek için bir denetleyici gerçekledik. Özgün şerit
+    bölümleme tasarımız, \%97 doğruluklu sınıflandırıcımız, dayanıklı
+    planlayıcı ve kontrolcü algoritmalarımızla benzetimli ve gerçek
+    güzergahlarda başarılı sürüşler gerçekleştirdik.
 }
 %
 % Dedication


### PR DESCRIPTION
Fix typos and rewrite abstract without exceeding 2000 chars. Delete
behavior planning from keywords to limit the number of keywords to 5.